### PR TITLE
remove CMake option --pedantic-errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ project(mahjong)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_FLAGS "-Wall")
-set(CMAKE_CXX_FLAGS "--pedantic-errors")
 
 set(SOURCE_FILES main.cpp)
 add_executable(${CMAKE_PROJECT_NAME}.out ${SOURCE_FILES})


### PR DESCRIPTION
`--pedantic-errors` をONにするとgRPCでエラーになるようです
![スクリーンショット 2020-06-18 14 31 31](https://user-images.githubusercontent.com/34413567/84981860-707e4b80-b170-11ea-8c6e-52addc5039f5.png)
