### PR TITLE
Fix bug of ten expression for Tenhou

### DIFF
--- a/mahjong/state.cpp
+++ b/mahjong/state.cpp
@@ -275,7 +275,8 @@ namespace mj
         mutable_player(winner).Tsumo();
         auto [hand_info, win_score] = EvalWinHand(winner);
         // calc ten moves
-        auto [ten_, ten_moves] = win_score.TenMoves(winner, dealer());
+        auto ten_moves = win_score.TenMoves(winner, dealer());
+        auto ten_ = ten_moves[winner];
         for (auto &[who, ten_move]: ten_moves) {
             if (ten_move > 0) ten_move += riichi() * 1000 + honba() * 300;
             else if (ten_move < 0) ten_move -= honba() * 100;
@@ -331,7 +332,8 @@ namespace mj
         mutable_player(winner).Ron(tile);
         auto [hand_info, win_score] = EvalWinHand(winner);
         // calc ten moves
-        auto [ten_, ten_moves] = win_score.TenMoves(winner, dealer(), loser);
+        auto ten_moves = win_score.TenMoves(winner, dealer(), loser);
+        auto ten_ = ten_moves[winner];
         for (auto &[who, ten_move]: ten_moves) {
             if (ten_move > 0) ten_move += riichi() * 1000 + honba() * 300;
             else if (ten_move < 0) ten_move -= honba() * 300;

--- a/mahjong/win_score.cpp
+++ b/mahjong/win_score.cpp
@@ -136,7 +136,7 @@ namespace mj {
         };
     }
 
-    std::pair<int, std::map<AbsolutePos, int>>
+    std::map<AbsolutePos, int>
     WinScore::TenMoves(AbsolutePos winner, AbsolutePos dealer, std::optional<AbsolutePos> loser) const noexcept {
         static ScoreTable table;
 
@@ -146,41 +146,39 @@ namespace mj {
         int ten;
         std::map<AbsolutePos, int> ten_moves;
 
-        // スコアの移動だけでなく、和了の点数を求める（天鳳mjlogでの表示用）
-        // ロン和了の場合はそのままスコアの移動にもなる。
-        if (winner == dealer) {
-            // 親
-            if (!yakuman_.empty()) ten = 48000 * yakuman_.size();
-            else if (table.dealer_ron.count({fan, fu})) {
-                ten = table.dealer_ron.at({fan, fu});
-            }
-            else {
-                if (fan <= 5) ten = 12000;
-                else if (fan <= 7) ten = 18000;
-                else if (fan <= 10) ten = 24000;
-                else if (fan <= 12) ten = 36000;
-                else ten = 48000;
-            }
-        }
-        else {
-            // 子
-            if (!yakuman_.empty()) ten = 32000 * yakuman_.size();
-            else if (table.non_dealer_ron.count({fan, fu})) {
-                ten = table.non_dealer_ron.at({fan, fu});
-            }
-            else {
-                if (fan <= 5) ten = 8000;
-                else if (fan <= 7) ten = 12000;
-                else if (fan <= 10) ten = 16000;
-                else if (fan <= 12) ten = 24000;
-                else ten = 32000;
-            }
-        }
-
         if (loser) {  // ロン和了
+            if (winner == dealer) {
+                // 親
+                if (!yakuman_.empty()) ten = 48000 * yakuman_.size();
+                else if (table.dealer_ron.count({fan, fu})) {
+                    ten = table.dealer_ron.at({fan, fu});
+                }
+                else {
+                    if (fan <= 5) ten = 12000;
+                    else if (fan <= 7) ten = 18000;
+                    else if (fan <= 10) ten = 24000;
+                    else if (fan <= 12) ten = 36000;
+                    else ten = 48000;
+                }
+            }
+            else {
+                // 子
+                if (!yakuman_.empty()) ten = 32000 * yakuman_.size();
+                else if (table.non_dealer_ron.count({fan, fu})) {
+                    ten = table.non_dealer_ron.at({fan, fu});
+                }
+                else {
+                    if (fan <= 5) ten = 8000;
+                    else if (fan <= 7) ten = 12000;
+                    else if (fan <= 10) ten = 16000;
+                    else if (fan <= 12) ten = 24000;
+                    else ten = 32000;
+                }
+            }
             ten_moves[winner] = ten;
             ten_moves[loser.value()] = -ten;
-        } else {  // ツモ和了
+        } else {
+            // ツモ和了
             if (winner == dealer) {
                 // 親がツモ上がりしたとき
                 int payment;
@@ -224,7 +222,7 @@ namespace mj {
             }
         }
 
-        return {ten, ten_moves};
+        return ten_moves;
     }
 
     void WinScore::AddYaku(Yaku yaku, int fan) noexcept {

--- a/mahjong/win_score.h
+++ b/mahjong/win_score.h
@@ -34,7 +34,7 @@ namespace mj {
         void set_fu(int fu) noexcept ;
         [[nodiscard]] bool RequireFan() const noexcept ;
         [[nodiscard]] bool RequireFu() const noexcept ;
-        [[nodiscard]] std::pair<int, std::map<AbsolutePos, int>>
+        [[nodiscard]] std::map<AbsolutePos, int>
         TenMoves(AbsolutePos winner, AbsolutePos dealer, std::optional<AbsolutePos> loser = std::nullopt) const noexcept ;
     };
 

--- a/test/win_score_test.cpp
+++ b/test/win_score_test.cpp
@@ -13,8 +13,7 @@ TEST(win_score, dealer_tsumo) {
     EXPECT_TRUE(score.HasYakuman(Yaku::kAllHonours));
 
     // 親のダブル役満
-    auto [ten, ten_moves] = score.TenMoves(AbsolutePos::kInitEast, AbsolutePos::kInitEast);
-    EXPECT_EQ(ten, 96000);
+    auto ten_moves = score.TenMoves(AbsolutePos::kInitEast, AbsolutePos::kInitEast);
     EXPECT_EQ(ten_moves[AbsolutePos::kInitEast], 96000);
     EXPECT_EQ(ten_moves[AbsolutePos::kInitSouth], -48000 * 2 / 3);
     EXPECT_EQ(ten_moves[AbsolutePos::kInitWest], -48000 * 2 / 3);
@@ -31,8 +30,7 @@ TEST(win_score, dealer_ron) {
     EXPECT_EQ(score.HasYaku(Yaku::kRiichi), std::make_optional(1));
     EXPECT_EQ(score.total_fan(), 3);
 
-    auto [ten, ten_moves] = score.TenMoves(AbsolutePos::kInitEast, AbsolutePos::kInitEast, AbsolutePos::kInitSouth);
-    EXPECT_EQ(ten, 4800);
+    auto ten_moves = score.TenMoves(AbsolutePos::kInitEast, AbsolutePos::kInitEast, AbsolutePos::kInitSouth);
     EXPECT_EQ(ten_moves[AbsolutePos::kInitEast], 4800);
     EXPECT_EQ(ten_moves[AbsolutePos::kInitSouth], -4800);
     EXPECT_EQ(ten_moves[AbsolutePos::kInitWest], 0);
@@ -51,8 +49,7 @@ TEST(win_score, non_dealer_tsumo) {
     EXPECT_EQ(score.total_fan(), 3);
     score.set_fu(30);
 
-    auto [ten, ten_moves] = score.TenMoves(AbsolutePos::kInitEast, AbsolutePos::kInitSouth);
-    EXPECT_EQ(ten, 3900);
+    auto ten_moves = score.TenMoves(AbsolutePos::kInitEast, AbsolutePos::kInitSouth);
     EXPECT_EQ(ten_moves[AbsolutePos::kInitEast], 4000);
     EXPECT_EQ(ten_moves[AbsolutePos::kInitSouth], -2000);
     EXPECT_EQ(ten_moves[AbsolutePos::kInitWest], -1000);
@@ -74,8 +71,7 @@ TEST(win_score, non_dealer_ron) {
     EXPECT_EQ(score.HasYaku(Yaku::kDora), std::make_optional(3));
     EXPECT_EQ(score.total_fan(), 9);
 
-    auto [ten, ten_moves] = score.TenMoves(AbsolutePos::kInitEast, AbsolutePos::kInitSouth, AbsolutePos::kInitWest);
-    EXPECT_EQ(ten, 16000);
+    auto ten_moves = score.TenMoves(AbsolutePos::kInitEast, AbsolutePos::kInitSouth, AbsolutePos::kInitWest);
     EXPECT_EQ(ten_moves[AbsolutePos::kInitEast], 16000);
     EXPECT_EQ(ten_moves[AbsolutePos::kInitSouth], 0);
     EXPECT_EQ(ten_moves[AbsolutePos::kInitWest], -16000);


### PR DESCRIPTION
例えばピンヅモ400-700のとき、点の表示は400 * 2 + 700 = 1500だった（ロン時の点数かと勘違いしていた）