### PR TITLE
mjlogファイルのDecode/Encodeの依存洗い出し

### DIFF
--- a/tenhou/requirements.txt
+++ b/tenhou/requirements.txt
@@ -1,0 +1,5 @@
+google
+protobuf
+grpcio
+grpcio-tools
+


### PR DESCRIPTION
cf https://github.com/sotetsuk/mahjong/issues/275

`requirements.txt`に依存しているモジュールを書き出した。

`pip install -r requirements.txt` でインストールできる。