### PR TITLE
Fix grpc generation path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ tenhou/resources/*
 !tenhou/resources/.gitkeep
 test/resources/*
 !test/resources/.gitkeep
+*.pb.cc
+*.pb.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,7 @@ set(CMAKE_CXX_FLAGS "-Wall")
 set(SOURCE_FILES main.cpp)
 add_executable(${PROJECT_NAME}.out ${SOURCE_FILES})
 
-include_directories(mahjong)
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/mahjong)  # to include generated gRPC files
+include_directories(.)
 
 add_subdirectory(mahjong)
 add_subdirectory(test)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 clean:
+	rm mahjong/*.pb.cc mahjong/*.pb.h
 	rm -rf build
 	rm -rf docker-build
 

--- a/mahjong/CMakeLists.txt
+++ b/mahjong/CMakeLists.txt
@@ -28,23 +28,22 @@ get_filename_component(mj_proto "../protos/mahjong.proto" ABSOLUTE)
 get_filename_component(mj_proto_path "${mj_proto}" PATH)
 
 # Generated sources
-set(mj_proto_srcs "${CMAKE_CURRENT_BINARY_DIR}/mahjong.pb.cc")
-set(mj_proto_hdrs "${CMAKE_CURRENT_BINARY_DIR}/mahjong.pb.h")
-set(mj_grpc_srcs "${CMAKE_CURRENT_BINARY_DIR}/mahjong.grpc.pb.cc")
-set(mj_grpc_hdrs "${CMAKE_CURRENT_BINARY_DIR}/mahjong.grpc.pb.h")
-message("CMAKE_CURRENT_BINARY_DIR = ${CMAKE_CURRENT_BINARY_DIR}")
+set(mj_proto_srcs "${CMAKE_CURRENT_SOURCE_DIR}/mahjong.pb.cc")
+set(mj_proto_hdrs "${CMAKE_CURRENT_SOURCE_DIR}/mahjong.pb.h")
+set(mj_grpc_srcs "${CMAKE_CURRENT_SOURCE_DIR}/mahjong.grpc.pb.cc")
+set(mj_grpc_hdrs "${CMAKE_CURRENT_SOURCE_DIR}/mahjong.grpc.pb.h")
 add_custom_command(
         OUTPUT "${mj_proto_srcs}" "${mj_proto_hdrs}" "${mj_grpc_srcs}" "${mj_grpc_hdrs}"
         COMMAND ${_PROTOBUF_PROTOC}
-        ARGS --grpc_out "${CMAKE_CURRENT_BINARY_DIR}"
-        --cpp_out "${CMAKE_CURRENT_BINARY_DIR}"
+        ARGS --grpc_out "${CMAKE_CURRENT_SOURCE_DIR}"
+        --cpp_out "${CMAKE_CURRENT_SOURCE_DIR}"
         -I "${mj_proto_path}"
         --plugin=protoc-gen-grpc="${_GRPC_CPP_PLUGIN_EXECUTABLE}"
         "${mj_proto}"
         DEPENDS "${mj_proto}")
 
 # Include generated *.pb.h files
-include_directories("${CMAKE_CURRENT_BINARY_DIR}")
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
 
 # Targets for quick gRPC execution test
 

--- a/mahjong/action.h
+++ b/mahjong/action.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 #include <utility>
-#include <mahjong.pb.h>
+#include "mahjong.pb.h"
 #include "types.h"
 #include "tile.h"
 #include "open.h"

--- a/mahjong/agent_client.h
+++ b/mahjong/agent_client.h
@@ -2,7 +2,7 @@
 #define MAHJONG_AGENT_CLIENT_H
 
 #include <grpcpp/grpcpp.h>
-#include <mahjong.grpc.pb.h>
+#include "mahjong.grpc.pb.h"
 #include "action.h"
 #include "observation.h"
 

--- a/mahjong/agent_server.h
+++ b/mahjong/agent_server.h
@@ -1,7 +1,7 @@
 #ifndef MAHJONG_AGENT_SERVER_H
 #define MAHJONG_AGENT_SERVER_H
 
-#include <mahjong.grpc.pb.h>
+#include "mahjong.grpc.pb.h"
 
 namespace mj
 {

--- a/mahjong/event.h
+++ b/mahjong/event.h
@@ -2,7 +2,7 @@
 #define MAHJONG_EVENT_H
 
 
-#include <mahjong.pb.h>
+#include "mahjong.pb.h"
 #include "types.h"
 #include "tile.h"
 #include "open.h"

--- a/mahjong/hand.h
+++ b/mahjong/hand.h
@@ -5,9 +5,9 @@
 #include <unordered_set>
 #include <set>
 #include <vector>
-
-#include <tile.h>
 #include <unordered_map>
+
+#include "tile.h"
 #include "open.h"
 #include "win_cache.h"
 #include "win_info.h"

--- a/mahjong/observation.h
+++ b/mahjong/observation.h
@@ -1,10 +1,10 @@
 #ifndef MAHJONG_OBSERVATION_H
 #define MAHJONG_OBSERVATION_H
 
-#include <mahjong.pb.h>
-
 #include <utility>
 #include <array>
+
+#include "mahjong.pb.h"
 #include "hand.h"
 #include "action.h"
 #include "player.h"

--- a/mahjong/open.cpp
+++ b/mahjong/open.cpp
@@ -1,10 +1,8 @@
 #include <bitset>
-#include <bitset>
-
-#include <open.h>
-#include <iostream>
 #include <cassert>
 #include <algorithm>
+
+#include "open.h"
 
 namespace mj
 {

--- a/mahjong/open.h
+++ b/mahjong/open.h
@@ -5,7 +5,7 @@
 #include <bitset>
 #include <memory>
 
-#include <tile.h>
+#include "tile.h"
 
 
 namespace mj

--- a/mahjong/player.cpp
+++ b/mahjong/player.cpp
@@ -1,6 +1,6 @@
-#include "player.h"
-
 #include <utility>
+
+#include "player.h"
 #include "utils.h"
 #include "yaku_evaluator.h"
 

--- a/mahjong/player.h
+++ b/mahjong/player.h
@@ -3,7 +3,7 @@
 
 #include "hand.h"
 #include "river.h"
-#include <mahjong.grpc.pb.h>
+#include "mahjong.grpc.pb.h"
 
 namespace mj
 {

--- a/mahjong/types.h
+++ b/mahjong/types.h
@@ -7,7 +7,7 @@
 #include <map>
 #include <unordered_map>
 
-#include <mahjong.pb.h>
+#include "mahjong.pb.h"
 
 namespace mj {
     using TileId = std::uint8_t;  // {0, ..., 135} corresponds to mjlog format of Tenhou

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-#include "mahjong/agent_server_mock.h"
+#include <mahjong/agent_server_mock.h>
 
 int main() {
     std::unique_ptr<mj::AgentServer> mock_agent =  std::make_unique<mj::MockAgentServer>();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,7 +7,6 @@ if(NOT EXISTS ${GOOGLETEST_DIR})
     )
 endif()
 
-include_directories(${CMAKE_BINARY_DIR}/mahjong)  # to include generated gRPC files
 include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
 add_subdirectory(${GOOGLETEST_DIR})
 

--- a/test/agent_client_mock.cpp
+++ b/test/agent_client_mock.cpp
@@ -1,6 +1,6 @@
 #include "gtest/gtest.h"
-#include "state.h"
-#include "agent_client_mock.h"
+#include <mahjong/state.h>
+#include <mahjong/agent_client_mock.h>
 
 using namespace mj;
 

--- a/test/hand_test.cpp
+++ b/test/hand_test.cpp
@@ -1,7 +1,7 @@
 #include <array>
 #include "gtest/gtest.h"
-#include "tile.h"
-#include "hand.h"
+#include <mahjong/tile.h>
+#include <mahjong/hand.h>
 
 using namespace mj;
 

--- a/test/observatoin_test.cpp
+++ b/test/observatoin_test.cpp
@@ -1,6 +1,6 @@
 #include "gtest/gtest.h"
-#include "observation.h"
-#include "state.h"
+#include "mahjong/observation.h"
+#include "mahjong/state.h"
 
 using namespace mj;
 

--- a/test/open_test.cpp
+++ b/test/open_test.cpp
@@ -1,5 +1,5 @@
 #include "gtest/gtest.h"
-#include "open.h"
+#include <mahjong/open.h>
 
 using namespace mj;
 

--- a/test/state_test.cpp
+++ b/test/state_test.cpp
@@ -2,8 +2,8 @@
 #include <fstream>
 #include <filesystem>
 #include <queue>
-#include "state.h"
-#include "utils.h"
+#include <mahjong/state.h>
+#include <mahjong/utils.h>
 #include <thread>
 #include <google/protobuf/util/message_differencer.h>
 

--- a/test/tile_test.cpp
+++ b/test/tile_test.cpp
@@ -1,5 +1,5 @@
 #include "gtest/gtest.h"
-#include "tile.h"
+#include <mahjong/tile.h>
 
 using namespace mj;
 

--- a/test/type_test.cpp
+++ b/test/type_test.cpp
@@ -1,5 +1,5 @@
 #include "gtest/gtest.h"
-#include "types.h"
+#include <mahjong/types.h>
 
 using namespace mj;
 

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -1,6 +1,6 @@
 #include "gtest/gtest.h"
-#include "types.h"
-#include "utils.h"
+#include <mahjong/types.h>
+#include <mahjong/utils.h>
 
 using namespace mj;
 

--- a/test/wall_seed_test.cpp
+++ b/test/wall_seed_test.cpp
@@ -1,5 +1,5 @@
 #include "gtest/gtest.h"
-#include "wall_seed.h"
+#include <mahjong/wall_seed.h>
 
 using namespace mj;
 

--- a/test/wall_test.cpp
+++ b/test/wall_test.cpp
@@ -1,5 +1,5 @@
 #include "gtest/gtest.h"
-#include "wall.h"
+#include <mahjong/wall.h>
 
 using namespace mj;
 

--- a/test/win_score_test.cpp
+++ b/test/win_score_test.cpp
@@ -1,6 +1,6 @@
 #include "gtest/gtest.h"
 
-#include "win_score.h"
+#include <mahjong/win_score.h>
 
 using namespace mj;
 

--- a/test/yaku_evaluator_test.cpp
+++ b/test/yaku_evaluator_test.cpp
@@ -1,8 +1,7 @@
 #include "gtest/gtest.h"
-#include "yaku_evaluator.h"
-
-#include "types.h"
-#include "hand.h"
+#include <mahjong/yaku_evaluator.h>
+#include <mahjong/types.h>
+#include <mahjong/hand.h>
 
 using namespace mj;
 


### PR DESCRIPTION
Generate grpc files to source dir to avoid including bin dir in cmake.

![image](https://user-images.githubusercontent.com/5868442/95254638-24f4c800-085b-11eb-9f50-a61bb677ed39.png)
