### PR TITLE
Environmentクラスのコンストラクタでplayer_idsを設定する部分を削除する 

### DIFF
--- a/mjx/internal/environment.cpp
+++ b/mjx/internal/environment.cpp
@@ -10,8 +10,6 @@ namespace mjx::internal {
 Environment::Environment(std::vector<std::shared_ptr<Agent>> agents)
     : agents_(std::move(agents)) {
   for (const auto &agent : agents_) map_agents_[agent->player_id()] = agent;
-  std::vector<PlayerId> player_ids(4);
-  for (int i = 0; i < 4; ++i) player_ids[i] = agents_.at(i)->player_id();
   state_ = State();
 }
 


### PR DESCRIPTION
cf. #803 