### PR TITLE
`State::ShufflePlayerIds`のseedを`uint64_t`型にする

### DIFF
--- a/mjx/internal/state.cpp
+++ b/mjx/internal/state.cpp
@@ -1709,7 +1709,7 @@ void State::SyncCurrHand(AbsolutePos who) {
       ->CopyFrom(mutable_hand(who).ToProto());
 }
 std::vector<PlayerId> State::ShufflePlayerIds(
-    std::uint32_t game_seed, const std::vector<PlayerId> &player_ids) {
+    std::uint64_t game_seed, const std::vector<PlayerId> &player_ids) {
   std::vector<PlayerId> ret(player_ids.begin(), player_ids.end());
   Shuffle(ret.begin(), ret.end(), std::mt19937_64(game_seed));
   return ret;

--- a/mjx/internal/state.h
+++ b/mjx/internal/state.h
@@ -53,7 +53,7 @@ class State {
   State::ScoreInfo Next() const;
 
   static std::vector<PlayerId> ShufflePlayerIds(
-      std::uint32_t game_seed, const std::vector<PlayerId>& player_ids);
+      std::uint64_t game_seed, const std::vector<PlayerId>& player_ids);
 
   // accessors
   [[nodiscard]] AbsolutePos dealer() const;


### PR DESCRIPTION
seedは`uint64_t`型に統一する