### PR TITLE
[py] Implement observe_all in MjxEnv

### DIFF
--- a/pymjx/mjx/env.py
+++ b/pymjx/mjx/env.py
@@ -1,5 +1,5 @@
 import random
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 import gym
 import numpy as np
@@ -9,10 +9,14 @@ import mjx
 
 
 class MjxEnv:
-    def __init__(self):
+    def __init__(
+        self,
+        player_ids: List[str] = ["player_0", "player_1", "player_2", "player_3"],
+        observe_all: bool = False,
+    ):
         import mjx._mjx as _mjx
 
-        self._env = _mjx.MjxEnv()
+        self._env = _mjx.MjxEnv(player_ids, observe_all)
 
     def seed(self, seed) -> None:
         self._env.seed(seed)

--- a/pymjx/mjx/pybind.cpp
+++ b/pymjx/mjx/pybind.cpp
@@ -56,7 +56,7 @@ PYBIND11_MODULE(_mjx, m) {
   py::class_<mjx::EnvRunner>(m, "EnvRunner").def("run", &mjx::EnvRunner::Run);
 
   py::class_<mjx::MjxEnv>(m, "MjxEnv")
-      .def(py::init<>())
+      .def(py::init<std::vector<mjx::PlayerId>, bool>())
       .def("reset", &mjx::MjxEnv::Reset)
       .def("step", &mjx::MjxEnv::Step)
       .def("done", &mjx::MjxEnv::Done)


### PR DESCRIPTION
```py
from mjx.env import MjxEnv
import random


random.seed(1234)
env = MjxEnv(observe_all=True)
env.seed(1234)
obs_dict = env.reset()
cnt = 0
while not env.done():
    env.state.save_svg(f"state_{cnt:03d}.svg")
    action_dict = {}
    for agent, obs in obs_dict.items():
        if agent == "player_0":
            obs.save_svg(f"obs_{cnt:03d}.svg", view_idx=0)
        legal_actions = obs.legal_actions()
        if not legal_actions:
            continue
        action_dict[agent] = random.choice(legal_actions)
    obs_dict = env.step(action_dict)
    cnt += 1
```