### PR TITLE
`internal::State::observation` を消す

### DIFF
--- a/include/mjx/internal/state.cpp
+++ b/include/mjx/internal/state.cpp
@@ -1737,15 +1737,6 @@ std::vector<PlayerId> State::ShufflePlayerIds(
   return ret;
 }
 
-mjxproto::Observation State::observation(const PlayerId &player_id) const {
-  for (int i = 0; i < 4; ++i) {
-    auto seat = AbsolutePos(i);
-    if (player(seat).player_id != player_id) continue;
-    auto obs = Observation(seat, state_);
-    return obs.proto_;
-  }
-}
-
 std::string State::ProtoToJson(const mjxproto::State &proto) {
   std::string serialized;
   auto status = google::protobuf::util::MessageToJsonString(proto, &serialized);

--- a/include/mjx/internal/state.h
+++ b/include/mjx/internal/state.h
@@ -51,7 +51,6 @@ class State {
   mjxproto::State proto() const;
   GameResult result() const;
   State::ScoreInfo Next() const;
-  mjxproto::Observation observation(const PlayerId& player_id) const;
 
   static std::vector<PlayerId> ShufflePlayerIds(
       std::uint64_t game_seed, const std::vector<PlayerId>& player_ids);


### PR DESCRIPTION
現状、 `legal_actions` が設定されておらず、不適切。