### PR TITLE
Stateの初期化時のAssertionをWarningに変える

### DIFF
--- a/include/mjx/internal/state.cpp
+++ b/include/mjx/internal/state.cpp
@@ -262,7 +262,7 @@ State::State(const mjxproto::State &state) {
   std::queue<mjxproto::Action> actions = EventsToActions(state);
   UpdateByActions(state, actions, *this);
   if (!google::protobuf::util::MessageDifferencer::Equals(state, proto())) {
-    std::cerr << "WARNING: restored state is different from the input:\n  "
+    std::cerr << "WARNING: Restored state is different from the input:\n  "
                  "Expected:\n  " +
                      ProtoToJson(state) + "\n  Actual:  \n  " + ToJson() + "\n";
   }


### PR DESCRIPTION
resolve #1008 

今の所、一致しないのは天鳳側の実装に問題がありそうな点だけなので、
Warningとしてだけ残すようにする